### PR TITLE
fix: have not callback completion in resetAudios

### DIFF
--- a/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
@@ -222,7 +222,7 @@ class SVGAVideoEntity {
                 return@map item
             }
             this.soundPool = soundPool
-        } ?: kotlin.run(completionBlock)
+        }.run { completionBlock() }
     }
 
 }


### PR DESCRIPTION
When video item have audios, after resetAudios, can not callback completion


如果 videoItem 里面有 audio，在 resetAudios 后，没有回调 completion，会导致有音频的 svga 不能播放