### PR TITLE
fix: audio file tag compatible

### DIFF
--- a/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
@@ -129,7 +129,7 @@ class SVGAVideoEntity {
                 return@forEach
             }
             val fileTag = byteArray.slice(IntRange(0, 3))
-            if (fileTag[0].toInt() == 73 && fileTag[1].toInt() == 68 && fileTag[2].toInt() == 51 && fileTag[3].toInt() == 3) {
+            if (fileTag[0].toInt() == 73 && fileTag[1].toInt() == 68 && fileTag[2].toInt() == 51) {
             } else {
                 val bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.count(), options)
                 if (bitmap != null) {
@@ -196,7 +196,7 @@ class SVGAVideoEntity {
                     return@forEach
                 }
                 val fileTag = byteArray.slice(IntRange(0, 3))
-                if (fileTag[0].toInt() == 73 && fileTag[1].toInt() == 68 && fileTag[2].toInt() == 51 && fileTag[3].toInt() == 3) {
+                if (fileTag[0].toInt() == 73 && fileTag[1].toInt() == 68 && fileTag[2].toInt() == 51) {
                     audiosData[imageKey] = byteArray
                 }
             }


### PR DESCRIPTION
fileTag[3].toInt() == 3 || fileTag[3].toInt() == 4

我用 Animate CC 2017 导出带音频 svga，音频文件的 FileTag[3] 的值是 4，不确定具体原因，先兼容上。