### PR TITLE
修复 SVGAImageView、SVGAParser 内存泄漏问题

### DIFF
--- a/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
@@ -131,15 +131,6 @@ open class SVGAImageView : ImageView {
         mAnimator = animator
     }
 
-    private fun onAnimatorUpdate(animator: ValueAnimator?) {
-        if (mDrawable == null) {
-            return
-        }
-        mDrawable!!.currentFrame = animator?.animatedValue as Int
-        val percentage = (mDrawable!!.currentFrame + 1).toDouble() / mDrawable!!.videoItem?.frames?.toDouble()
-        callback?.onStep(mDrawable!!.currentFrame, percentage)
-    }
-
     @Suppress("UNNECESSARY_SAFE_CALL")
     private fun generateScale(): Double {
         var scale = 1.0
@@ -162,6 +153,15 @@ open class SVGAImageView : ImageView {
         } catch (ignore: Exception) {
         }
         return scale
+    }
+
+    private fun onAnimatorUpdate(animator: ValueAnimator?) {
+        if (mDrawable == null) {
+            return
+        }
+        mDrawable!!.currentFrame = animator?.animatedValue as Int
+        val percentage = (mDrawable!!.currentFrame + 1).toDouble() / mDrawable!!.videoItem.frames.toDouble()
+        callback?.onStep(mDrawable!!.currentFrame, percentage)
     }
 
     private fun onAnimationEnd(animation: Animator?) {

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAParser.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAParser.kt
@@ -22,7 +22,7 @@ import java.util.zip.ZipInputStream
 
 private var fileLock: Int = 0
 
-class SVGAParser(private var context: Context?) {
+class SVGAParser(context: Context?) {
     private var mContextRef = WeakReference<Context?>(context)
 
     interface ParseCompletion {


### PR DESCRIPTION
SVGAImageView#loadAttrs 中使用的匿名内部类 SVGAParser.ParseCompletion 会导致持有 SVGAImageView 的强引用，造成内存泄漏。