### PR TITLE
解决对同一个资源多次调用 SvgaParser.decodeFromAssets或 decodeFromUrl 时，内存会暴涨的问题

### DIFF
--- a/app/src/main/java/com/example/ponycui_home/svgaplayer/AnimationWithDynamicImageActivity.java
+++ b/app/src/main/java/com/example/ponycui_home/svgaplayer/AnimationWithDynamicImageActivity.java
@@ -19,7 +19,7 @@ import java.net.URL;
 public class AnimationWithDynamicImageActivity extends Activity {
 
     SVGAImageView animationView = null;
-    SVGAParser parser = new SVGAParser(this);
+    SVGAParser parser = new SVGAParser();
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/example/ponycui_home/svgaplayer/MainActivity.java
+++ b/app/src/main/java/com/example/ponycui_home/svgaplayer/MainActivity.java
@@ -157,7 +157,6 @@ public class MainActivity extends AppCompatActivity {
         this.listView.setBackgroundColor(Color.WHITE);
     }
     void setupSVGAParser() {
-        SVGAParser.Companion.shareParser().init(this);
     }
 
 

--- a/library/src/main/java/com/opensource/svgaplayer/SVGADynamicEntity.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGADynamicEntity.kt
@@ -8,7 +8,6 @@ import android.text.StaticLayout
 import android.text.TextPaint
 import java.net.HttpURLConnection
 import java.net.URL
-import kotlin.concurrent.thread
 
 /**
  * Created by cuiminghui on 2017/3/30.
@@ -50,7 +49,7 @@ class SVGADynamicEntity {
 
     fun setDynamicImage(url: String, forKey: String) {
         val handler = android.os.Handler()
-        SVGAParser.threadPoolExecutor.execute {
+        SVGAParser.getThreadPoolExecutor().execute {
             (URL(url).openConnection() as? HttpURLConnection)?.let {
                 try {
                     it.connectTimeout = 20 * 1000

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
@@ -11,6 +11,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.animation.LinearInterpolator
 import android.widget.ImageView
+import com.opensource.svgaplayer.task.DecodeParseCenter
 import com.opensource.svgaplayer.utils.SVGARange
 import java.lang.ref.WeakReference
 import java.net.URL
@@ -61,6 +62,10 @@ open class SVGAImageView : ImageView {
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
         setSoftwareLayerType()
         attrs?.let { loadAttrs(it) }
+    }
+
+    init {
+        DecodeParseCenter.initCenter(context)
     }
 
     private fun setSoftwareLayerType() {
@@ -282,7 +287,7 @@ open class SVGAImageView : ImageView {
          * 使用弱引用解决内存泄漏
          */
         private val weakReference = WeakReference<SVGAImageView>(view)
-        private val parser = SVGAParser(view.context)
+        private val parser = SVGAParser()
 
         override fun run() {
             if (source.startsWith("http://") || source.startsWith("https://")) {

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAParser.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAParser.kt
@@ -1,29 +1,16 @@
 package com.opensource.svgaplayer
 
-import android.content.Context
-import android.net.http.HttpResponseCache
-import android.os.Handler
-import android.util.Log
-import com.opensource.svgaplayer.proto.MovieEntity
-import org.json.JSONObject
-import java.io.*
-import java.lang.ref.WeakReference
-import java.net.HttpURLConnection
+import com.opensource.svgaplayer.task.DecodeParseCenter
 import java.net.URL
-import java.security.MessageDigest
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadPoolExecutor
-import java.util.zip.Inflater
-import java.util.zip.ZipInputStream
 
 /**
  * Created by PonyCui 16/6/18.
  */
 
-private var fileLock: Int = 0
-
-class SVGAParser(context: Context?) {
-    private var mContextRef = WeakReference<Context?>(context)
+class SVGAParser() {
 
     interface ParseCompletion {
 
@@ -31,140 +18,35 @@ class SVGAParser(context: Context?) {
         fun onError()
     }
 
-    open class FileDownloader {
-
-        var noCache = false
-
-        open fun resume(url: URL, complete: (inputStream: InputStream) -> Unit, failure: (e: Exception) -> Unit): () -> Unit {
-            var cancelled = false
-            val cancelBlock = {
-                cancelled = true
-            }
-            threadPoolExecutor.execute {
-                try {
-                    if (HttpResponseCache.getInstalled() == null && !noCache) {
-                        Log.e("SVGAParser", "SVGAParser can not handle cache before install HttpResponseCache. see https://github.com/yyued/SVGAPlayer-Android#cache")
-                        Log.e("SVGAParser", "在配置 HttpResponseCache 前 SVGAParser 无法缓存. 查看 https://github.com/yyued/SVGAPlayer-Android#cache ")
-                    }
-                    (url.openConnection() as? HttpURLConnection)?.let {
-                        it.connectTimeout = 20 * 1000
-                        it.requestMethod = "GET"
-                        it.connect()
-                        it.inputStream.use { inputStream ->
-                            ByteArrayOutputStream().use { outputStream ->
-                                val buffer = ByteArray(4096)
-                                var count: Int
-                                while (true) {
-                                    if (cancelled) {
-                                        break
-                                    }
-                                    count = inputStream.read(buffer, 0, 4096)
-                                    if (count == -1) {
-                                        break
-                                    }
-                                    outputStream.write(buffer, 0, count)
-                                }
-                                if (cancelled) {
-                                    return@execute
-                                }
-                                ByteArrayInputStream(outputStream.toByteArray()).use {
-                                    complete(it)
-                                }
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    failure(e)
-                }
-            }
-            return cancelBlock
-        }
-
-    }
-
-    var fileDownloader = FileDownloader()
-
     companion object {
-        internal var threadPoolExecutor = Executors.newCachedThreadPool()
+        private var threadPoolExecutor = Executors.newCachedThreadPool()
+
         fun setThreadPoolExecutor(executor: ThreadPoolExecutor) {
             threadPoolExecutor = executor
         }
-        private var mShareParser = SVGAParser(null)
+
+        fun getThreadPoolExecutor(): ExecutorService {
+            if (threadPoolExecutor == null) {
+                threadPoolExecutor = Executors.newCachedThreadPool()
+            } else if (threadPoolExecutor.isShutdown) {
+                threadPoolExecutor = Executors.newCachedThreadPool()
+            }
+            return threadPoolExecutor
+        }
+
+        private var mShareParser = SVGAParser()
         fun shareParser(): SVGAParser {
             return mShareParser
-        }
-    }
-
-    fun init(context: Context) {
-        mContextRef = WeakReference<Context?>(context)
-    }
-
-    fun decodeFromAssets(name: String, callback: ParseCompletion?) {
-        if (mContextRef.get() == null) {
-            Log.e("SVGAParser", "在配置 SVGAParser context 前, 无法解析 SVGA 文件。")
-        }
-        try {
-            mContextRef.get()?.assets?.open(name)?.let {
-                this.decodeFromInputStream(it, buildCacheKey("file:///assets/$name"), callback, true)
-            }
-        }
-        catch (e: java.lang.Exception) {
-            this.invokeErrorCallback(e, callback)
-        }
-    }
-
-    fun decodeFromURL(url: URL, callback: ParseCompletion?): (() -> Unit)? {
-        if (this.isCached(buildCacheKey(url))) {
-            threadPoolExecutor.execute {
-                this.decodeFromCacheKey(buildCacheKey(url), callback)
-            }
-            return null
-        }
-        else {
-            return fileDownloader.resume(url, {
-                this.decodeFromInputStream(it, this.buildCacheKey(url), callback)
-            }, {
-                this.invokeErrorCallback(it, callback)
-            })
-        }
-    }
-
-    fun decodeFromInputStream(inputStream: InputStream, cacheKey: String, callback: ParseCompletion?, closeInputStream: Boolean = false) {
-        threadPoolExecutor.execute {
-            try {
-                readAsBytes(inputStream)?.let { bytes ->
-                    if (bytes.size > 4 && bytes[0].toInt() == 80 && bytes[1].toInt() == 75 && bytes[2].toInt() == 3 && bytes[3].toInt() == 4) {
-                        if (!buildCacheDir(cacheKey).exists()) {
-                            ByteArrayInputStream(bytes).use {
-                                unzip(it, cacheKey)
-                            }
-                        }
-                        this.decodeFromCacheKey(cacheKey, callback)
-                    }
-                    else {
-                        inflate(bytes)?.let {
-                            val videoItem = SVGAVideoEntity(MovieEntity.ADAPTER.decode(it), File(cacheKey))
-                            videoItem.prepare {
-                                this.invokeCompleteCallback(videoItem, callback)
-                            }
-                        }
-                    }
-                }
-            } catch (e: java.lang.Exception) {
-                this.invokeErrorCallback(e, callback)
-            } finally {
-                if (closeInputStream) {
-                    inputStream.close()
-                }
-            }
         }
     }
 
     /**
      * @deprecated from 2.4.0
      */
-    @Deprecated("This method has been deprecated from 2.4.0.", ReplaceWith("this.decodeFromAssets(assetsName, callback)"))
+    @Deprecated(
+            "This method has been deprecated from 2.4.0.",
+            ReplaceWith("this.decodeFromAssets(assetsName, callback)")
+    )
     fun parse(assetsName: String, callback: ParseCompletion?) {
         this.decodeFromAssets(assetsName, callback)
     }
@@ -172,170 +54,20 @@ class SVGAParser(context: Context?) {
     /**
      * @deprecated from 2.4.0
      */
-    @Deprecated("This method has been deprecated from 2.4.0.", ReplaceWith("this.decodeFromURL(url, callback)"))
+    @Deprecated(
+            "This method has been deprecated from 2.4.0.",
+            ReplaceWith("this.decodeFromURL(url, callback)")
+    )
     fun parse(url: URL, callback: ParseCompletion?) {
         this.decodeFromURL(url, callback)
     }
 
-    /**
-     * @deprecated from 2.4.0
-     */
-    @Deprecated("This method has been deprecated from 2.4.0.", ReplaceWith("this.decodeFromInputStream(inputStream, cacheKey, callback, closeInputStream)"))
-    fun parse(inputStream: InputStream, cacheKey: String, callback: ParseCompletion?, closeInputStream: Boolean = false) {
-        this.decodeFromInputStream(inputStream, cacheKey, callback, closeInputStream)
+    fun decodeFromAssets(name: String, callback: ParseCompletion?) {
+        DecodeParseCenter.addTask(name, callback)
     }
 
-    private fun invokeCompleteCallback(videoItem: SVGAVideoEntity, callback: ParseCompletion?) {
-        if (mContextRef.get() == null) {
-            Log.e("SVGAParser", "在配置 SVGAParser context 前, 无法解析 SVGA 文件。")
-        }
-        Handler(mContextRef.get()?.mainLooper).post {
-            callback?.onComplete(videoItem)
-        }
+    fun decodeFromURL(url: URL, callback: ParseCompletion?) {
+        DecodeParseCenter.addTask(url, callback)
     }
 
-    private fun invokeErrorCallback(e: java.lang.Exception, callback: ParseCompletion?) {
-        e.printStackTrace()
-        if (mContextRef.get() == null) {
-            Log.e("SVGAParser", "在配置 SVGAParser context 前, 无法解析 SVGA 文件。")
-        }
-        Handler(mContextRef.get()?.mainLooper).post {
-            callback?.onError()
-        }
-    }
-
-    private fun isCached(cacheKey: String): Boolean {
-        return buildCacheDir(cacheKey).exists()
-    }
-
-    private fun decodeFromCacheKey(cacheKey: String, callback: ParseCompletion?) {
-        if (mContextRef.get() == null) {
-            Log.e("SVGAParser", "在配置 SVGAParser context 前, 无法解析 SVGA 文件。")
-        }
-        try {
-            val cacheDir = File(mContextRef.get()?.cacheDir?.absolutePath + "/" + cacheKey + "/")
-            File(cacheDir, "movie.binary").takeIf { it.isFile }?.let { binaryFile ->
-                try {
-                    FileInputStream(binaryFile).use {
-                        this.invokeCompleteCallback(SVGAVideoEntity(MovieEntity.ADAPTER.decode(it), cacheDir), callback)
-                    }
-                } catch (e: Exception) {
-                    cacheDir.delete()
-                    binaryFile.delete()
-                    throw e
-                }
-            }
-            File(cacheDir, "movie.spec").takeIf { it.isFile }?.let { jsonFile ->
-                try {
-                    FileInputStream(jsonFile).use { fileInputStream ->
-                        ByteArrayOutputStream().use { byteArrayOutputStream ->
-                            val buffer = ByteArray(2048)
-                            while (true) {
-                                val size = fileInputStream.read(buffer, 0, buffer.size)
-                                if (size == -1) {
-                                    break
-                                }
-                                byteArrayOutputStream.write(buffer, 0, size)
-                            }
-                            byteArrayOutputStream.toString().let {
-                                JSONObject(it).let {
-                                    this.invokeCompleteCallback(SVGAVideoEntity(it, cacheDir), callback)
-                                }
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    cacheDir.delete()
-                    jsonFile.delete()
-                    throw e
-                }
-            }
-        } catch (e: Exception) {
-            this.invokeErrorCallback(e, callback)
-        }
-    }
-
-    private fun buildCacheKey(str: String): String {
-        val messageDigest = MessageDigest.getInstance("MD5")
-        messageDigest.update(str.toByteArray(charset("UTF-8")))
-        val digest = messageDigest.digest()
-        var sb = ""
-        for (b in digest) {
-            sb += String.format("%02x", b)
-        }
-        return sb
-    }
-
-    private fun buildCacheKey(url: URL): String = buildCacheKey(url.toString())
-
-    private fun buildCacheDir(cacheKey: String): File = File(mContextRef.get()?.cacheDir?.absolutePath + "/" + cacheKey + "/")
-
-    private fun readAsBytes(inputStream: InputStream): ByteArray? {
-        ByteArrayOutputStream().use { byteArrayOutputStream ->
-            val byteArray = ByteArray(2048)
-            while (true) {
-                val count = inputStream.read(byteArray, 0, 2048)
-                if (count <= 0) {
-                    break
-                }
-                else {
-                    byteArrayOutputStream.write(byteArray, 0, count)
-                }
-            }
-            return byteArrayOutputStream.toByteArray()
-        }
-    }
-
-    private fun inflate(byteArray: ByteArray): ByteArray? {
-        val inflater = Inflater()
-        inflater.setInput(byteArray, 0, byteArray.size)
-        val inflatedBytes = ByteArray(2048)
-        ByteArrayOutputStream().use { inflatedOutputStream ->
-            while (true) {
-                val count = inflater.inflate(inflatedBytes, 0, 2048)
-                if (count <= 0) {
-                    break
-                }
-                else {
-                    inflatedOutputStream.write(inflatedBytes, 0, count)
-                }
-            }
-            inflater.end()
-            return inflatedOutputStream.toByteArray()
-        }
-    }
-
-    private fun unzip(inputStream: InputStream, cacheKey: String) {
-        synchronized(fileLock) {
-            val cacheDir = this.buildCacheDir(cacheKey)
-            cacheDir.mkdirs()
-            try {
-                BufferedInputStream(inputStream).use {
-                    ZipInputStream(it).use { zipInputStream ->
-                        while (true) {
-                            val zipItem = zipInputStream.nextEntry ?: break
-                            if (zipItem.name.contains("/")) {
-                                continue
-                            }
-                            val file = File(cacheDir, zipItem.name)
-                            FileOutputStream(file).use { fileOutputStream ->
-                                val buff = ByteArray(2048)
-                                while (true) {
-                                    val readBytes = zipInputStream.read(buff)
-                                    if (readBytes <= 0) {
-                                        break
-                                    }
-                                    fileOutputStream.write(buff, 0, readBytes)
-                                }
-                            }
-                            zipInputStream.closeEntry()
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                cacheDir.delete()
-                throw e
-            }
-        }
-    }
 }

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeAssetsTask.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeAssetsTask.kt
@@ -1,0 +1,20 @@
+package com.opensource.svgaplayer.task
+
+import com.opensource.svgaplayer.SVGAParser
+
+class DecodeAssetsTask(path: String, callback: SVGAParser.ParseCompletion?) :
+        DecodeTask(path, callback) {
+
+    fun getPath(): String = "file:///assets/$url"
+
+    override fun run() {
+        try {
+            DecodeParseCenter.getFromAssets(url).let { stream ->
+                DecodeParseCenter.decodeInputStream(this, stream, true)
+            }
+        } catch (e: Exception) {
+            DecodeParseCenter.invokeErrorCallback(taskCacheKey, e)
+        }
+    }
+
+}

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeAssetsTask.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeAssetsTask.kt
@@ -2,6 +2,9 @@ package com.opensource.svgaplayer.task
 
 import com.opensource.svgaplayer.SVGAParser
 
+/**
+ * 解析 assets 任务
+ */
 class DecodeAssetsTask(path: String, callback: SVGAParser.ParseCompletion?) :
         DecodeTask(path, callback) {
 

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeParseCenter.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeParseCenter.kt
@@ -1,0 +1,418 @@
+package com.opensource.svgaplayer.task
+
+import android.content.Context
+import android.os.Handler
+import android.os.Message
+import android.util.Log
+import android.util.LruCache
+import com.opensource.svgaplayer.SVGAParser
+import com.opensource.svgaplayer.SVGAVideoEntity
+import com.opensource.svgaplayer.proto.MovieEntity
+import com.opensource.svgaplayer.utils.ResUtil
+import org.json.JSONObject
+import java.io.*
+import java.net.URL
+import java.security.MessageDigest
+import java.util.*
+import java.util.concurrent.TimeUnit
+import java.util.zip.Inflater
+import java.util.zip.ZipInputStream
+
+object DecodeParseCenter {
+
+    private val TAG = DecodeParseCenter::class.java.simpleName
+
+    private var fileLock: Int = 0
+
+    private const val MSG_TASK_RUN_IF_NEED = 1
+    private const val MSG_TASK_CANCEL = 2
+    private const val MSG_TASK_CLEAR = 3
+
+    private const val MSG_TASK_SUCCESS = 4
+    private const val MSG_TASK_FAIL = 5
+
+    private const val MSG_TASK_ADD_BY_URL = 6
+    private const val MSG_TASK_ADD_BY_ASSETS = 7
+
+    /**
+     * 可同时运行的最大任务数量
+     */
+    private var mMaxTasks = 5
+
+    /**
+     * 最大的缓存数量
+     */
+    private var mMaxCache = 5
+
+    /**
+     * 等待队列
+     */
+    private val mWaitTasks = LinkedList<DecodeTask>()
+
+    /**
+     * 运行栈
+     */
+    private val mRunningTasks = mutableMapOf<String, DecodeTask>()
+
+    private val mHandler: DecodeParseHandler by lazy {
+        DecodeParseHandler()
+    }
+
+    private var mEntityCache: LruCache<String, SVGAVideoEntity>? = null
+
+    private var mContext: Context? = null
+
+
+    init {
+        mEntityCache = object : LruCache<String, SVGAVideoEntity>(mMaxCache) {
+        }
+    }
+
+    fun initCenter(context: Context) {
+        mContext = context.applicationContext
+    }
+
+    fun addTask(url: URL, callback: SVGAParser.ParseCompletion?): String {
+        val key = buildCacheKey(url.toString())
+
+        val entity = getCache(key)
+        entity?.let {
+            callback?.onComplete(it)
+            return key
+        }
+
+        val task = DecodeUrlTask(url.toString(), callback)
+        task.taskCacheKey = key
+        mHandler.sendMsg(MSG_TASK_ADD_BY_URL, task)
+
+        return key
+    }
+
+    fun addTask(assets: String, callback: SVGAParser.ParseCompletion?): String {
+
+        val task = DecodeAssetsTask(assets, callback)
+        val key = buildCacheKey(task.getPath())
+
+        val entity = getCache(key)
+        entity?.let {
+            callback?.onComplete(it)
+            return key
+        }
+
+        task.taskCacheKey = key
+        mHandler.sendMsg(MSG_TASK_ADD_BY_ASSETS, task)
+
+        return key
+    }
+
+    private fun dealTaskUrl(task: DecodeUrlTask) {
+        mWaitTasks.add(task)
+        mHandler.sendMsg(MSG_TASK_RUN_IF_NEED)
+    }
+
+    private fun dealTaskAssets(task: DecodeAssetsTask) {
+        mWaitTasks.add(task)
+        mHandler.sendMsg(MSG_TASK_RUN_IF_NEED)
+    }
+
+    /**
+     * 从缓存中查找
+     */
+    fun getCache(taskCacheKey: String): SVGAVideoEntity? {
+        return mEntityCache?.get(taskCacheKey)
+    }
+
+    /**
+     * 加载任务
+     */
+    fun runTasks() {
+        while (mRunningTasks.size < mMaxTasks) {
+            val task = mWaitTasks.poll()
+            task ?: break
+            val entity = getCache(task.taskCacheKey)
+            if (entity == null) {
+                if (mRunningTasks[task.taskCacheKey] == null) {
+                    mRunningTasks[task.taskCacheKey] = task
+                    SVGAParser.getThreadPoolExecutor().execute(task)
+                }
+            } else {
+                task.callback?.onComplete(entity)
+            }
+        }
+    }
+
+    fun getFromAssets(path: String): InputStream {
+        if (mContext == null) {
+            throw IllegalArgumentException("please call initCenter first")
+        }
+        return ResUtil.getFromAssets(mContext!!, path)
+    }
+
+    fun decodeInputStream(task: DecodeTask, inputStream: InputStream, closeInputStream: Boolean) {
+        try {
+            readAsBytes(inputStream)?.let { bytes ->
+                if (bytes.size > 4 && bytes[0].toInt() == 80 && bytes[1].toInt() == 75 && bytes[2].toInt() == 3 && bytes[3].toInt() == 4) {
+                    if (!buildCacheDir(task.taskCacheKey).exists()) {
+                        ByteArrayInputStream(bytes).use {
+                            unzip(it, task.taskCacheKey)
+                        }
+                    }
+                    decodeFromCacheKey(task.taskCacheKey)
+                } else {
+                    inflate(bytes)?.let {
+                        val videoItem =
+                                SVGAVideoEntity(MovieEntity.ADAPTER.decode(it), File(task.taskCacheKey))
+                        videoItem.prepare {
+                            invokeCompleteCallback(task.taskCacheKey, videoItem)
+                        }
+                    }
+                }
+            }
+        } catch (e: java.lang.Exception) {
+            invokeErrorCallback(task.taskCacheKey, e)
+        } finally {
+            if (closeInputStream) {
+                inputStream.close()
+            }
+        }
+    }
+
+    fun decodeFromCacheKey(cacheKey: String) {
+        if (mContext == null) {
+            Log.e(TAG, "please call initCenter first")
+        }
+        try {
+            val cacheDir = File(mContext?.cacheDir?.absolutePath + "/" + cacheKey + "/")
+            File(cacheDir, "movie.binary").takeIf { it.isFile }?.let { binaryFile ->
+                try {
+                    FileInputStream(binaryFile).use {
+                        invokeCompleteCallback(
+                                cacheKey,
+                                SVGAVideoEntity(MovieEntity.ADAPTER.decode(it), cacheDir)
+                        )
+                    }
+                } catch (e: Exception) {
+                    cacheDir.delete()
+                    binaryFile.delete()
+                    throw e
+                }
+            }
+            File(cacheDir, "movie.spec").takeIf { it.isFile }?.let { jsonFile ->
+                try {
+                    FileInputStream(jsonFile).use { fileInputStream ->
+                        ByteArrayOutputStream().use { byteArrayOutputStream ->
+                            val buffer = ByteArray(2048)
+                            while (true) {
+                                val size = fileInputStream.read(buffer, 0, buffer.size)
+                                if (size == -1) {
+                                    break
+                                }
+                                byteArrayOutputStream.write(buffer, 0, size)
+                            }
+                            byteArrayOutputStream.toString().let {
+                                JSONObject(it).let { json ->
+                                    invokeCompleteCallback(
+                                            cacheKey,
+                                            SVGAVideoEntity(json, cacheDir)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    cacheDir.delete()
+                    jsonFile.delete()
+                    throw e
+                }
+            }
+        } catch (e: Exception) {
+            invokeErrorCallback(cacheKey, e)
+        }
+    }
+
+    fun hasDiskCached(cacheKey: String): Boolean {
+        return buildCacheDir(cacheKey).exists()
+    }
+
+    private fun readAsBytes(inputStream: InputStream): ByteArray? {
+        ByteArrayOutputStream().use { byteArrayOutputStream ->
+            val byteArray = ByteArray(2048)
+            while (true) {
+                val count = inputStream.read(byteArray, 0, 2048)
+                if (count <= 0) {
+                    break
+                } else {
+                    byteArrayOutputStream.write(byteArray, 0, count)
+                }
+            }
+            return byteArrayOutputStream.toByteArray()
+        }
+    }
+
+    private fun inflate(byteArray: ByteArray): ByteArray? {
+        val inflater = Inflater()
+        inflater.setInput(byteArray, 0, byteArray.size)
+        val inflatedBytes = ByteArray(2048)
+        ByteArrayOutputStream().use { inflatedOutputStream ->
+            while (true) {
+                val count = inflater.inflate(inflatedBytes, 0, 2048)
+                if (count <= 0) {
+                    break
+                } else {
+                    inflatedOutputStream.write(inflatedBytes, 0, count)
+                }
+            }
+            inflater.end()
+            return inflatedOutputStream.toByteArray()
+        }
+    }
+
+    private fun unzip(inputStream: InputStream, cacheKey: String) {
+        synchronized(fileLock) {
+            val cacheDir = buildCacheDir(cacheKey)
+            cacheDir.mkdirs()
+            try {
+                BufferedInputStream(inputStream).use {
+                    ZipInputStream(it).use { zipInputStream ->
+                        while (true) {
+                            val zipItem = zipInputStream.nextEntry ?: break
+                            if (zipItem.name.contains("/")) {
+                                continue
+                            }
+                            val file = File(cacheDir, zipItem.name)
+                            FileOutputStream(file).use { fileOutputStream ->
+                                val buff = ByteArray(2048)
+                                while (true) {
+                                    val readBytes = zipInputStream.read(buff)
+                                    if (readBytes <= 0) {
+                                        break
+                                    }
+                                    fileOutputStream.write(buff, 0, readBytes)
+                                }
+                            }
+                            zipInputStream.closeEntry()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                cacheDir.delete()
+                throw e
+            }
+        }
+    }
+
+    private fun buildCacheDir(cacheKey: String): File =
+            File(mContext?.cacheDir?.absolutePath + "/" + cacheKey + "/")
+
+    fun removeTask(taskCacheKey: String) {
+        var targetTask: DecodeTask? = null
+        for (task in mWaitTasks) {
+            if (taskCacheKey == task.taskCacheKey) {
+                targetTask = task
+            }
+        }
+        targetTask?.let {
+            mWaitTasks.remove(it)
+            return
+        }
+        mRunningTasks.remove(taskCacheKey)
+    }
+
+    fun clearAllTask() {
+        mWaitTasks.clear()
+        mRunningTasks.clear()
+        val pool = SVGAParser.getThreadPoolExecutor()
+        try {
+            pool.shutdown()
+            if (!pool.awaitTermination(1, TimeUnit.SECONDS)) {
+                pool.shutdownNow()
+            }
+        } catch (e: Exception) {
+            pool.shutdownNow()
+        }
+    }
+
+    private fun buildCacheKey(str: String): String {
+        val messageDigest = MessageDigest.getInstance("MD5")
+        messageDigest.update(str.toByteArray(charset("UTF-8")))
+        val digest = messageDigest.digest()
+        var sb = ""
+        for (b in digest) {
+            sb += String.format("%02x", b)
+        }
+        return sb
+    }
+
+    fun invokeCompleteCallback(taskCacheKey: String, entity: SVGAVideoEntity) {
+        if (mContext == null) {
+            Log.e(TAG, "please call initCenter first")
+        }
+        mHandler.sendMsg(MSG_TASK_SUCCESS, DecodeResult(taskCacheKey, entity = entity))
+    }
+
+    fun invokeErrorCallback(taskCacheKey: String, e: java.lang.Exception) {
+        e.printStackTrace()
+        if (mContext == null) {
+            Log.e(TAG, "please call initCenter first")
+        }
+        mHandler.sendMsg(MSG_TASK_FAIL, DecodeResult(taskCacheKey, error = e))
+    }
+
+    private fun dealSuccess(result: DecodeResult) {
+        val task = mRunningTasks.remove(result.taskKey)
+        task?.callback?.let { callback ->
+            result.entity?.let {
+                callback.onComplete(it)
+                mEntityCache?.put(result.taskKey, it)
+            }
+        }
+    }
+
+    private fun dealFail(result: DecodeResult) {
+        val task = mRunningTasks.remove(result.taskKey)
+        task?.callback?.onError()
+    }
+
+    private class DecodeParseHandler : Handler() {
+
+        fun sendMsg(what: Int, target: Any? = null) {
+            if (target == null) {
+                sendEmptyMessage(what)
+            } else {
+                val msg = this.obtainMessage()
+                msg.what = what
+                msg.obj = target
+                sendMessage(msg)
+            }
+        }
+
+        override fun handleMessage(msg: Message?) {
+            msg?.let { m ->
+                when (m.what) {
+                    MSG_TASK_ADD_BY_URL -> {
+                        dealTaskUrl(m.obj as DecodeUrlTask)
+                    }
+                    MSG_TASK_ADD_BY_ASSETS -> {
+                        dealTaskAssets(m.obj as DecodeAssetsTask)
+                    }
+                    MSG_TASK_RUN_IF_NEED -> {
+                        runTasks()
+                    }
+                    MSG_TASK_CANCEL -> {
+                        removeTask(m.obj as String)
+                    }
+                    MSG_TASK_CLEAR -> {
+                        clearAllTask()
+                    }
+                    MSG_TASK_SUCCESS -> {
+                        dealSuccess(msg.obj as DecodeResult)
+                    }
+                    MSG_TASK_FAIL -> {
+                        dealFail(msg.obj as DecodeResult)
+                    }
+                }
+            }
+            super.handleMessage(msg)
+        }
+    }
+}

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeResult.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeResult.kt
@@ -1,0 +1,11 @@
+package com.opensource.svgaplayer.task
+
+import com.opensource.svgaplayer.SVGAVideoEntity
+
+class DecodeResult(
+        val taskKey: String,
+        val entity: SVGAVideoEntity? = null,
+        val error: Exception? = null
+) {
+    fun isSuccess() = error == null
+}

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeResult.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeResult.kt
@@ -2,6 +2,9 @@ package com.opensource.svgaplayer.task
 
 import com.opensource.svgaplayer.SVGAVideoEntity
 
+/**
+ * 解析结果
+ */
 class DecodeResult(
         val taskKey: String,
         val entity: SVGAVideoEntity? = null,

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeTask.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeTask.kt
@@ -1,0 +1,10 @@
+package com.opensource.svgaplayer.task
+
+import com.opensource.svgaplayer.SVGAParser
+
+abstract class DecodeTask(
+        val url: String,
+        val callback: SVGAParser.ParseCompletion?
+) : Runnable {
+    var taskCacheKey: String = ""
+}

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeTask.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeTask.kt
@@ -2,6 +2,9 @@ package com.opensource.svgaplayer.task
 
 import com.opensource.svgaplayer.SVGAParser
 
+/**
+ * 解析任务
+ */
 abstract class DecodeTask(
         val url: String,
         val callback: SVGAParser.ParseCompletion?

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeUrlTask.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeUrlTask.kt
@@ -4,7 +4,11 @@ import com.opensource.svgaplayer.SVGAParser
 import com.opensource.svgaplayer.utils.FileDownloader
 import java.net.URL
 
-class DecodeUrlTask(url: String, callback: SVGAParser.ParseCompletion?) : DecodeTask(url, callback) {
+/**
+ * 解析 url 任务
+ */
+class DecodeUrlTask(url: String, callback: SVGAParser.ParseCompletion?) :
+        DecodeTask(url, callback) {
 
     override fun run() {
         try {
@@ -17,7 +21,6 @@ class DecodeUrlTask(url: String, callback: SVGAParser.ParseCompletion?) : Decode
                     DecodeParseCenter.invokeErrorCallback(taskCacheKey, e)
                 })
             }
-
         } catch (e: Exception) {
             DecodeParseCenter.invokeErrorCallback(taskCacheKey, e)
         }

--- a/library/src/main/java/com/opensource/svgaplayer/task/DecodeUrlTask.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/task/DecodeUrlTask.kt
@@ -1,0 +1,25 @@
+package com.opensource.svgaplayer.task
+
+import com.opensource.svgaplayer.SVGAParser
+import com.opensource.svgaplayer.utils.FileDownloader
+import java.net.URL
+
+class DecodeUrlTask(url: String, callback: SVGAParser.ParseCompletion?) : DecodeTask(url, callback) {
+
+    override fun run() {
+        try {
+            if (DecodeParseCenter.hasDiskCached(taskCacheKey)) {
+                DecodeParseCenter.decodeFromCacheKey(taskCacheKey)
+            } else {
+                FileDownloader.resume(URL(url), { stream ->
+                    DecodeParseCenter.decodeInputStream(this, stream, true)
+                }, { e ->
+                    DecodeParseCenter.invokeErrorCallback(taskCacheKey, e)
+                })
+            }
+
+        } catch (e: Exception) {
+            DecodeParseCenter.invokeErrorCallback(taskCacheKey, e)
+        }
+    }
+}

--- a/library/src/main/java/com/opensource/svgaplayer/utils/FileDownloader.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/utils/FileDownloader.kt
@@ -1,0 +1,67 @@
+package com.opensource.svgaplayer.utils
+
+import android.net.http.HttpResponseCache
+import android.util.Log
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+object FileDownloader {
+
+
+    fun resume(
+            url: URL,
+            complete: (inputStream: InputStream) -> Unit,
+            failure: (e: Exception) -> Unit
+    ): () -> Unit {
+        var cancelled = false
+        val cancelBlock = {
+            cancelled = true
+        }
+        try {
+            if (HttpResponseCache.getInstalled() == null) {
+                Log.e(
+                        "FileDownloader",
+                        "FileDownloader can not handle cache before install HttpResponseCache. see https://github.com/yyued/SVGAPlayer-Android#cache"
+                )
+                Log.e(
+                        "FileDownloader",
+                        "在配置 HttpResponseCache 前 FileDownloader 无法缓存. 查看 https://github.com/yyued/SVGAPlayer-Android#cache "
+                )
+            }
+            (url.openConnection() as? HttpURLConnection)?.let {
+                it.connectTimeout = 20 * 1000
+                it.requestMethod = "GET"
+                it.connect()
+                it.inputStream.use { inputStream ->
+                    ByteArrayOutputStream().use { outputStream ->
+                        val buffer = ByteArray(4096)
+                        var count: Int
+                        while (true) {
+                            if (cancelled) {
+                                break
+                            }
+                            count = inputStream.read(buffer, 0, 4096)
+                            if (count == -1) {
+                                break
+                            }
+                            outputStream.write(buffer, 0, count)
+                        }
+                        if (cancelled) {
+                            return cancelBlock
+                        }
+                        ByteArrayInputStream(outputStream.toByteArray()).use {
+                            complete(it)
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            failure(e)
+        }
+        return cancelBlock
+    }
+}

--- a/library/src/main/java/com/opensource/svgaplayer/utils/ResUtil.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/utils/ResUtil.kt
@@ -1,0 +1,11 @@
+package com.opensource.svgaplayer.utils
+
+import android.content.Context
+import java.io.InputStream
+
+object ResUtil {
+
+    fun getFromAssets(context: Context, path: String): InputStream {
+        return context.assets.open(path)
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ You can also create `SVGAParser` instance by yourself.
 #### Create a `SVGAParser` instance, parse from assets like this.
 
 ```kotlin
-parser = new SVGAParser(this);
+parser = new SVGAParser();
 parser.decodeFromAssets("posche.svga", new SVGAParser.ParseCompletion() {
     // ...
 });
@@ -152,7 +152,7 @@ parser.decodeFromAssets("posche.svga", new SVGAParser.ParseCompletion() {
 #### Create a `SVGAParser` instance, parse from remote server like this.
 
 ```kotlin
-parser = new SVGAParser(this);
+parser = new SVGAParser();
 parser.decodeFromURL(new URL("https://github.com/yyued/SVGA-Samples/blob/master/posche.svga?raw=true"), new SVGAParser.ParseCompletion() {
     
 });
@@ -161,7 +161,7 @@ parser.decodeFromURL(new URL("https://github.com/yyued/SVGA-Samples/blob/master/
 #### Create a `SVGADrawable` instance then set to `SVGAImageView`, play it as you want.
 
 ```kotlin
-parser = new SVGAParser(this);
+parser = new SVGAParser();
 parser.decodeFromURL(..., new SVGAParser.ParseCompletion() {
     @Override
     public void onComplete(@NotNull SVGAVideoEntity videoItem) {

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -128,7 +128,7 @@ SVGAParser.shareParser().init(this);
 #### 创建一个 `SVGAParser` 实例，加载 assets 中的动画。
 
 ```kotlin
-parser = new SVGAParser(this);
+parser = new SVGAParser();
 parser.decodeFromAssets("posche.svga", new SVGAParser.ParseCompletion() {
     
 });
@@ -137,7 +137,7 @@ parser.decodeFromAssets("posche.svga", new SVGAParser.ParseCompletion() {
 #### 创建一个 `SVGAParser` 实例，加载远端服务器中的动画。
 
 ```kotlin
-parser = new SVGAParser(this);
+parser = new SVGAParser();
 parser.decodeFromURL(new URL("https://github.com/yyued/SVGA-Samples/blob/master/posche.svga?raw=true"), new SVGAParser.ParseCompletion() {
     
 });
@@ -146,7 +146,7 @@ parser.decodeFromURL(new URL("https://github.com/yyued/SVGA-Samples/blob/master/
 #### 创建一个 `SVGADrawable` 实例，并赋值给 `SVGAImageView`，然后播放动画。
 
 ```kotlin
-parser = new SVGAParser(this);
+parser = new SVGAParser();
 parser.decodeFromURL(..., new SVGAParser.ParseCompletion() {
     @Override
     public void onComplete(@NotNull SVGAVideoEntity videoItem) {


### PR DESCRIPTION
之前有人反馈过 svga 在使用时内存会暴涨的问题，通过排查，是他们在使用 svga 时，是直接通过解析 svga 文件，然后完成播放，所以问题就出在 parse 的方法，通过测试重复 parse 方式加载 asset svga 文件，可以看到 memory 增长如下：
正常播放 svga memory 增长
![Image](https://raw.githubusercontent.com/painld6/image_repository/master/svga/%E6%AD%A3%E5%B8%B8%E6%92%AD%E6%94%BE%E4%B8%80%E6%AC%A1.png)
快速点击后再查看 memory 的增长（每次点击时都重新 parse 解析 svga 文件，然后再播放）
![Image](https://raw.githubusercontent.com/painld6/image_repository/master/svga/%E5%A4%9A%E6%AC%A1%E7%82%B9%E5%87%BB.png)
可以很明显看到 memory 在疯狂增长，这是因为没有控制和缓存资源，于是考虑加了队列处理资源加载的问题。通过设置任务队列的方式，把请求通过类似任务栈的形式一个个加入到解析队列中，并且把解析完成的数据暂时缓存在 LruCache 中，方便下次直接使用。
新增 task 包，其中 DecodeParseCenter 是 SvgaParser 中拆分出来的，包含各种 decode 相关方法，
DecodeTask 则是对应的解析任务，创建完成后则添加到 DecodeParseCenter 中，等待调度。
新增类
![Image](https://raw.githubusercontent.com/painld6/image_repository/master/svga/%E5%8C%85%E5%86%85%E4%BF%A1%E6%81%AF.png)
通过这次优化后再次尝试多次点击（仍然通过直接 parse 解析 svga 文件后再播放）
优化后多次点击
![Image](https://raw.githubusercontent.com/painld6/image_repository/master/svga/%E4%BC%98%E5%8C%96%E5%90%8E%E5%A4%9A%E6%AC%A1%E7%82%B9%E5%87%BB.png)
至此，明显可以看到问题已经解决