### PR TITLE
建议不要使用默认的kotlin_module的moduleName

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,6 +10,9 @@ android {
         versionCode 1
         versionName "1.0"
     }
+    compileOptions {
+        kotlinOptions.freeCompilerArgs += ['-module-name', "com.opensource.svgaplayer"]
+    }
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
如果不指定kotlin_module的module名字，用默认的library的话，会容易会引起一些编译冲突
> More than one file was found with OS independent path 'META-INF/library_release.kotlin_module'
虽然主项目可以配`exclude`可以解决这个问题
不过，还是从源头上减少此类问题发生比较好