### PR TITLE
[enhance]: 增加字段控制onDetachFromWindow时是否清空动画资源

### DIFF
--- a/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
@@ -6,7 +6,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.animation.LinearInterpolator
@@ -34,6 +33,7 @@ open class SVGAImageView @JvmOverloads constructor(context: Context, attrs: Attr
 
     var loops = 0
     var clearsAfterStop = true
+    var clearOnDetachFromWindow = true
     var fillMode: FillMode = FillMode.Forward
     var callback: SVGACallback? = null
 
@@ -57,6 +57,7 @@ open class SVGAImageView @JvmOverloads constructor(context: Context, attrs: Attr
         val typedArray = context.theme.obtainStyledAttributes(attrs, R.styleable.SVGAImageView, 0, 0)
         loops = typedArray.getInt(R.styleable.SVGAImageView_loopCount, 0)
         clearsAfterStop = typedArray.getBoolean(R.styleable.SVGAImageView_clearsAfterStop, true)
+        clearOnDetachFromWindow = typedArray.getBoolean(R.styleable.SVGAImageView_clearOnDetachFromWindow, true)
         mAntiAlias = typedArray.getBoolean(R.styleable.SVGAImageView_antiAlias, true)
         mAutoPlay = typedArray.getBoolean(R.styleable.SVGAImageView_autoPlay, true)
         typedArray.getString(R.styleable.SVGAImageView_fillMode)?.let {
@@ -245,7 +246,7 @@ open class SVGAImageView @JvmOverloads constructor(context: Context, attrs: Attr
         stepToFrame(frame, andPlay)
     }
 
-    fun setOnAnimKeyClickListener(clickListener : SVGAClickAreaListener){
+    fun setOnAnimKeyClickListener(clickListener: SVGAClickAreaListener) {
         mItemClickAreaListener = clickListener
     }
 
@@ -270,7 +271,9 @@ open class SVGAImageView @JvmOverloads constructor(context: Context, attrs: Attr
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         stopAnimation(true)
-        clear()
+        if (clearOnDetachFromWindow) {
+            clear()
+        }
     }
 
     private class AnimatorListener(view: SVGAImageView) : Animator.AnimatorListener {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -6,6 +6,7 @@
         <attr name="antiAlias" format="boolean" />
         <attr name="loopCount" format="integer" />
         <attr name="clearsAfterStop" format="boolean" />
+        <attr name="clearOnDetachFromWindow" format="boolean" />
         <attr name="fillMode" format="enum">
             <enum name="Backward" value="0" />
             <enum name="Forward" value="1" />


### PR DESCRIPTION
项目中将svga使用到了RecyclerView上，当item走了onDetachFromWindow方法后，动画资源被清空了，不符合业务逻辑，增加了clearOnDetachFromWindow字段，来控制在onDetachFromWindow时是否清空动画资源。