### PR TITLE
fix: matte 区域错误

### DIFF
--- a/app/src/main/java/com/example/ponycui_home/svgaplayer/AnimationFromAssetsActivity.java
+++ b/app/src/main/java/com/example/ponycui_home/svgaplayer/AnimationFromAssetsActivity.java
@@ -58,17 +58,22 @@ public class AnimationFromAssetsActivity extends Activity {
 
     private String randomSample() {
         if (samples.size() == 0) {
-            samples.add("gradientBorder.svga");
-            samples.add("Goddess.svga");
-            samples.add("Rocket.svga");
-            samples.add("angel.svga");
+            samples.add("750x80.svga");
             samples.add("alarm.svga");
-            samples.add("EmptyState.svga");
-            samples.add("heartbeat.svga");
-            samples.add("posche.svga");
-            samples.add("rose_2.0.0.svga");
+            samples.add("angel.svga");
             samples.add("Castle.svga");
+            samples.add("EmptyState.svga");
+            samples.add("Goddess.svga");
+            samples.add("gradientBorder.svga");
+            samples.add("heartbeat.svga");
+            samples.add("matteBitmap.svga");
+            samples.add("matteBitmap_1.x.svga");
+            samples.add("matteRect.svga");
             samples.add("MerryChristmas.svga");
+            samples.add("posche.svga");
+            samples.add("Rocket.svga");
+            samples.add("rose.svga");
+            samples.add("rose_2.0.0.svga");
         }
         return samples.get((int) Math.floor(Math.random() * samples.size()));
     }

--- a/library/src/main/java/com/opensource/svgaplayer/drawer/SVGACanvasDrawer.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/drawer/SVGACanvasDrawer.kt
@@ -202,14 +202,14 @@ internal class SVGACanvasDrawer(videoItem: SVGAVideoEntity, val dynamicItem: SVG
             maskPath.buildPath(path)
             path.transform(frameMatrix)
             canvas.clipPath(path)
-            frameMatrix.preScale((sprite.frameEntity.layout.width / drawingBitmap.width).toFloat(), (sprite.frameEntity.layout.width / drawingBitmap.width).toFloat())
+            frameMatrix.preScale((sprite.frameEntity.layout.width / drawingBitmap.width).toFloat(), (sprite.frameEntity.layout.height / drawingBitmap.height).toFloat())
             if (!drawingBitmap.isRecycled) {
                 canvas.drawBitmap(drawingBitmap, frameMatrix, paint)
             }
             canvas.restore()
         }
         else {
-            frameMatrix.preScale((sprite.frameEntity.layout.width / drawingBitmap.width).toFloat(), (sprite.frameEntity.layout.width / drawingBitmap.width).toFloat())
+            frameMatrix.preScale((sprite.frameEntity.layout.width / drawingBitmap.width).toFloat(), (sprite.frameEntity.layout.height / drawingBitmap.height).toFloat())
             if (!drawingBitmap.isRecycled) {
                 canvas.drawBitmap(drawingBitmap, frameMatrix, paint)
             }


### PR DESCRIPTION
修复蒙层区域错误，仅当设计师设置的宽高比例和图片的宽高比例不符时出现，如下图所示

修复前
![](https://raw.githubusercontent.com/painld6/image_repository/master/svga/svga_error_gp.jpg)
修复后
![](https://raw.githubusercontent.com/painld6/image_repository/master/svga/svga_correct.png)