### PR TITLE
更换修改ValueAnimator#sDurationScale的方式。修复targetSdkVersion=29，开发者选项关闭动画缩放…

### DIFF
--- a/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
@@ -149,17 +149,19 @@ open class SVGAImageView @JvmOverloads constructor(context: Context, attrs: Attr
         var scale = 1.0
         try {
             val animatorClass = Class.forName("android.animation.ValueAnimator") ?: return scale
-            val field = animatorClass.getDeclaredField("sDurationScale") ?: return scale
-            field.isAccessible = true
-            scale = field.getFloat(animatorClass).toDouble()
+            val getMethod = animatorClass.getDeclaredMethod("getDurationScale") ?: return scale
+            scale = (getMethod.invoke(animatorClass) as Float).toDouble()
             if (scale == 0.0) {
-                field.setFloat(animatorClass, 1.0f)
+                val setMethod = animatorClass.getDeclaredMethod("setDurationScale",Float::class.java) ?: return scale
+                setMethod.isAccessible = true
+                setMethod.invoke(animatorClass,1.0f)
                 scale = 1.0
                 LogUtils.info(TAG,
                         "The animation duration scale has been reset to" +
                                 " 1.0x, because you closed it on developer options.")
             }
         } catch (ignore: Exception) {
+            ignore.printStackTrace()
         }
         return scale
     }


### PR DESCRIPTION
更换修改ValueAnimator#sDurationScale的方式。targetSdkVersion=29，原修改方式失效