### PR TITLE
SVGASoundManager 优化以及其他 issue 修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # SVGAPlayer-Android CHANGELOG (2021-03-02)
 
+## [2.6.0](2021-08-18)
+
+## Features
+
+* feat(SVGASoundManager): Added SVGASoundManager to control SVGA audio, you need to manually call the init method to initialize, otherwise follow the default audio loading logic.
+* feat(SVGAParser): SVGAParser#decodeFromAssets and SVGAParser#decodeFromURL add a parameter, which can be null. It is used to send the audio file back to the developer. The developer can control the audio playback by himself. If this parameter is set, the audio part will not be processed internally.
+* feat(SVGAParser): Add aliases to the log section to facilitate developers to troubleshoot problems
+* feat(SVGACache): Open cache cleaning method: SVGACache#clearCache().
+
+### Bug Fixes
+
+* refactor(ILogger): Remove redundant api.
+* fix(SoundPool): Added SVGASoundManager to solve the problem that the internal SoundPool does not load audio occasionally.
+* fix(SVGAParser): Zip Path Traversal Vulnerability.
+* fix(SVGAParser): link reuse problem.
 
 ## [2.5.15](https://github.com/svga/SVGAPlayer-Android/compare/2.5.14...2.5.15) (2021-03-02)
 

--- a/app/src/main/java/com/example/ponycui_home/svgaplayer/AnimationFromAssetsActivity.java
+++ b/app/src/main/java/com/example/ponycui_home/svgaplayer/AnimationFromAssetsActivity.java
@@ -36,7 +36,7 @@ public class AnimationFromAssetsActivity extends Activity {
             }
         });
         SVGALogger.INSTANCE.setLogEnabled(true);
-        SVGASoundManager.Companion.get().init();
+        SVGASoundManager.INSTANCE.init();
         loadAnimation();
         setContentView(animationView);
     }

--- a/library/src/main/java/com/opensource/svgaplayer/SVGACache.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGACache.kt
@@ -56,7 +56,7 @@ object SVGACache {
     }
 
     // 清除目录下的所有文件
-    private fun clearDir(path: String) {
+    internal fun clearDir(path: String) {
         try {
             val dir = File(path)
             dir.takeIf { it.exists() }?.let { parentDir ->

--- a/library/src/main/java/com/opensource/svgaplayer/SVGACache.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGACache.kt
@@ -1,19 +1,33 @@
 package com.opensource.svgaplayer
 
 import android.content.Context
+import com.opensource.svgaplayer.utils.log.LogUtils
 import java.io.File
 import java.net.URL
 import java.security.MessageDigest
 
-
+/**
+ * SVGA 缓存管理
+ */
 object SVGACache {
     enum class Type {
         DEFAULT,
         FILE
     }
 
+    private const val TAG = "SVGACache"
     private var type: Type = Type.DEFAULT
     private var cacheDir: String = "/"
+        get() {
+            if (field != "/") {
+                val dir = File(field)
+                if (!dir.exists()) {
+                    dir.mkdirs()
+                }
+            }
+            return field
+        }
+
 
     fun onCreate(context: Context?) {
         onCreate(context, Type.DEFAULT)
@@ -27,22 +41,54 @@ object SVGACache {
         this.type = type
     }
 
-//    fun clearCache(context: Context?){
-//        context ?: return
-//        cacheDir = "${context.cacheDir.absolutePath}/svga/"
-//        File(cacheDir).takeIf { it.exists() }?.delete()
-//    }
+    /**
+     * 清理缓存
+     */
+    fun clearCache() {
+        if (!isInitialized()) {
+            LogUtils.error(TAG, "SVGACache is not init!")
+            return
+        }
+        SVGAParser.threadPoolExecutor.execute {
+            clearDir(cacheDir)
+            LogUtils.info(TAG, "Clear svga cache done!")
+        }
+    }
+
+    // 清除目录下的所有文件
+    private fun clearDir(path: String) {
+        try {
+            val dir = File(path)
+            dir.takeIf { it.exists() }?.let { parentDir ->
+                parentDir.listFiles()?.forEach { file ->
+                    if (!file.exists()) {
+                        return@forEach
+                    }
+                    if (file.isDirectory) {
+                        clearDir(file.absolutePath)
+                    }
+                    file.delete()
+                }
+            }
+        } catch (e: Exception) {
+            LogUtils.error(TAG, "Clear svga cache path: $path fail", e)
+        }
+    }
 
     fun isInitialized(): Boolean {
-        return "/" != cacheDir&&File(cacheDir).exists()
+        return "/" != cacheDir && File(cacheDir).exists()
     }
 
     fun isDefaultCache(): Boolean = type == Type.DEFAULT
 
     fun isCached(cacheKey: String): Boolean {
-        return (if (isDefaultCache()) buildCacheDir(cacheKey) else buildSvgaFile(
-                cacheKey
-        )).exists()
+        return if (isDefaultCache()) {
+            buildCacheDir(cacheKey)
+        } else {
+            buildSvgaFile(
+                    cacheKey
+            )
+        }.exists()
     }
 
     fun buildCacheKey(str: String): String {

--- a/library/src/main/java/com/opensource/svgaplayer/SVGADrawable.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGADrawable.kt
@@ -57,8 +57,8 @@ class SVGADrawable(val videoItem: SVGAVideoEntity, val dynamicItem: SVGADynamicE
     fun resume() {
         videoItem.audioList.forEach { audio ->
             audio.playID?.let {
-                if (SVGASoundManager.get().isInit()){
-                    SVGASoundManager.get().resume(it)
+                if (SVGASoundManager.isInit()){
+                    SVGASoundManager.resume(it)
                 }else{
                     videoItem.soundPool?.resume(it)
                 }
@@ -69,8 +69,8 @@ class SVGADrawable(val videoItem: SVGAVideoEntity, val dynamicItem: SVGADynamicE
     fun pause() {
         videoItem.audioList.forEach { audio ->
             audio.playID?.let {
-                if (SVGASoundManager.get().isInit()){
-                    SVGASoundManager.get().pause(it)
+                if (SVGASoundManager.isInit()){
+                    SVGASoundManager.pause(it)
                 }else{
                     videoItem.soundPool?.pause(it)
                 }
@@ -81,8 +81,8 @@ class SVGADrawable(val videoItem: SVGAVideoEntity, val dynamicItem: SVGADynamicE
     fun stop() {
         videoItem.audioList.forEach { audio ->
             audio.playID?.let {
-                if (SVGASoundManager.get().isInit()){
-                    SVGASoundManager.get().stop(it)
+                if (SVGASoundManager.isInit()){
+                    SVGASoundManager.stop(it)
                 }else{
                     videoItem.soundPool?.stop(it)
                 }
@@ -93,8 +93,8 @@ class SVGADrawable(val videoItem: SVGAVideoEntity, val dynamicItem: SVGADynamicE
     fun clear() {
         videoItem.audioList.forEach { audio ->
             audio.playID?.let {
-                if (SVGASoundManager.get().isInit()){
-                    SVGASoundManager.get().stop(it)
+                if (SVGASoundManager.isInit()){
+                    SVGASoundManager.stop(it)
                 }else{
                     videoItem.soundPool?.stop(it)
                 }

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAParser.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAParser.kt
@@ -63,6 +63,7 @@ class SVGAParser(context: Context?) {
                     (url.openConnection() as? HttpURLConnection)?.let {
                         it.connectTimeout = 20 * 1000
                         it.requestMethod = "GET"
+                        it.setRequestProperty("Connection", "close")
                         it.connect()
                         it.inputStream.use { inputStream ->
                             ByteArrayOutputStream().use { outputStream ->

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAParser.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAParser.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.http.HttpResponseCache
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import com.opensource.svgaplayer.proto.MovieEntity
 import com.opensource.svgaplayer.utils.log.LogUtils
 import org.json.JSONObject
@@ -20,7 +19,6 @@ import java.util.zip.ZipInputStream
 /**
  * Created by PonyCui 16/6/18.
  */
-
 private var fileLock: Int = 0
 private var isUnzipping = false
 
@@ -134,21 +132,32 @@ class SVGAParser(context: Context?) {
         mFrameHeight = frameHeight
     }
 
-    fun decodeFromAssets(name: String, callback: ParseCompletion?,playCallback: PlayCallback?=null) {
+    fun decodeFromAssets(
+            name: String,
+            callback: ParseCompletion?,
+            playCallback: PlayCallback? = null
+    ) {
         if (mContext == null) {
             LogUtils.error(TAG, "在配置 SVGAParser context 前, 无法解析 SVGA 文件。")
             return
         }
-        try {
-            LogUtils.info(TAG, "================ decode from assets ================")
-            threadPoolExecutor.execute {
+        LogUtils.info(TAG, "================ decode from assets ================")
+        threadPoolExecutor.execute {
+            try {
                 mContext?.assets?.open(name)?.let {
-                    this.decodeFromInputStream(it, SVGACache.buildCacheKey("file:///assets/$name"), callback, true,playCallback)
+                    this.decodeFromInputStream(
+                            it,
+                            SVGACache.buildCacheKey("file:///assets/$name"),
+                            callback,
+                            true,
+                            playCallback
+                    )
                 }
+            } catch (e: java.lang.Exception) {
+                this.invokeErrorCallback(e, callback)
             }
-        } catch (e: java.lang.Exception) {
-            this.invokeErrorCallback(e, callback)
         }
+
     }
 
     fun decodeFromURL(url: URL, callback: ParseCompletion?,playCallback: PlayCallback?=null): (() -> Unit)? {
@@ -234,8 +243,8 @@ class SVGAParser(context: Context?) {
     fun _decodeFromInputStream(
             inputStream: InputStream,
             cacheKey: String,
-            callback: ParseCompletion?
-    ,playCallback: PlayCallback?
+            callback: ParseCompletion?,
+            playCallback: PlayCallback?
     ) {
         threadPoolExecutor.execute {
             try {
@@ -269,7 +278,7 @@ class SVGAParser(context: Context?) {
                         videoItem.prepare({
                             LogUtils.info(TAG, "cache.prepare success")
                             this.invokeCompleteCallback(videoItem, callback)
-                        },playCallback)
+                        }, playCallback)
                     } ?: doError("Input.inflate(bytes) cause exception", callback)
                 } ?: doError("Input.readAsBytes(inputStream) cause exception", callback)
             } catch (e: Exception) {

--- a/library/src/main/java/com/opensource/svgaplayer/SVGASoundManager.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGASoundManager.kt
@@ -15,15 +15,15 @@ import java.io.FileDescriptor
 /**
  * Author : llk
  * Time : 2020/10/24
- * Description : svga音频加载管理类
- * 将SoundPool抽取到单例里边，规避load资源之后不回调onLoadComplete的问题。
+ * Description : svga 音频加载管理类
+ * 将 SoundPool 抽取到单例里边，规避 load 资源之后不回调 onLoadComplete 的问题。
  *
- * 需要对SVGASoundManager进行初始化
+ * 需要对 SVGASoundManager 进行初始化
  *
- * 相关文章：Android SoundPool崩溃问题研究
+ * 相关文章：Android SoundPool 崩溃问题研究
  * https://zhuanlan.zhihu.com/p/29985198
  */
-class SVGASoundManager private constructor(){
+object SVGASoundManager {
 
     private val TAG = SVGASoundManager::class.java.simpleName
 
@@ -46,18 +46,18 @@ class SVGASoundManager private constructor(){
         fun onComplete()
     }
 
-    fun init(){
+    fun init() {
         init(20)
     }
 
-    fun init(maxStreams : Int) {
+    fun init(maxStreams: Int) {
         LogUtils.debug(TAG, "**************** init **************** $maxStreams")
-        if(soundPool!=null){
+        if (soundPool != null) {
             return
         }
         soundPool = getSoundPool(maxStreams)
         soundPool?.setOnLoadCompleteListener { _, soundId, status ->
-            LogUtils.info(TAG, "SoundPool onLoadComplete soundId=$soundId status=$status")
+            LogUtils.debug(TAG, "SoundPool onLoadComplete soundId=$soundId status=$status")
             if (status == 0) { //加载该声音成功
                 if (completeCallBackMap.containsKey(soundId)) {
                     completeCallBackMap[soundId]?.onComplete()
@@ -66,7 +66,7 @@ class SVGASoundManager private constructor(){
         }
     }
 
-    fun release(){
+    fun release() {
         LogUtils.debug(TAG, "**************** release ****************")
         if (completeCallBackMap.isNotEmpty()){
             completeCallBackMap.clear()
@@ -76,13 +76,13 @@ class SVGASoundManager private constructor(){
     /**
      * 是否初始化
      * 如果没有初始化，就使用原来SvgaPlayer库的音频加载逻辑。
-     * @return -
+     * @return true 则已初始化， 否则为 false
      */
-    fun isInit() :Boolean{
+    internal fun isInit(): Boolean {
         return soundPool != null
     }
 
-    private fun checkInit() :Boolean{
+    private fun checkInit(): Boolean {
         val isInit = isInit()
         if (!isInit) {
             LogUtils.error(TAG, "soundPool is null, you need call init() !!!")
@@ -90,7 +90,7 @@ class SVGASoundManager private constructor(){
         return isInit
     }
 
-    private fun getSoundPool(maxStreams : Int) = if (Build.VERSION.SDK_INT >= 21) {
+    private fun getSoundPool(maxStreams: Int) = if (Build.VERSION.SDK_INT >= 21) {
         val attributes = AudioAttributes.Builder()
                 .setUsage(AudioAttributes.USAGE_MEDIA)
                 .build()
@@ -110,7 +110,7 @@ class SVGASoundManager private constructor(){
 
         val soundId = soundPool!!.load(fd, offset, length, priority)
 
-        LogUtils.info(TAG, "load soundId=$soundId callBack=$callBack")
+        LogUtils.debug(TAG, "load soundId=$soundId callBack=$callBack")
 
         if (callBack != null && !completeCallBackMap.containsKey(soundId)) {
             completeCallBackMap[soundId] = callBack
@@ -118,10 +118,10 @@ class SVGASoundManager private constructor(){
         return soundId
     }
 
-    fun unload(soundId: Int) {
+    internal fun unload(soundId: Int) {
         if (!checkInit()) return
 
-        LogUtils.info(TAG, "unload soundId=$soundId")
+        LogUtils.debug(TAG, "unload soundId=$soundId")
 
         soundPool!!.unload(soundId)
 
@@ -140,21 +140,21 @@ class SVGASoundManager private constructor(){
         return soundPool!!.play(soundId, leftVolume, rightVolume, priority, loop, rate)
     }
 
-    fun stop(soundId: Int) {
+    internal fun stop(soundId: Int) {
         if (!checkInit()) return
 
         LogUtils.debug(TAG, "stop soundId=$soundId")
         soundPool!!.stop(soundId)
     }
 
-    fun resume(soundId: Int) {
+    internal fun resume(soundId: Int) {
         if (!checkInit()) return
 
         LogUtils.debug(TAG, "stop soundId=$soundId")
         soundPool!!.resume(soundId)
     }
 
-    fun pause(soundId: Int) {
+    internal fun pause(soundId: Int) {
         if (!checkInit()) return
 
         LogUtils.debug(TAG, "pause soundId=$soundId")

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
@@ -43,7 +43,7 @@ class SVGAVideoEntity {
     internal var spriteList: List<SVGAVideoSpriteEntity> = emptyList()
     internal var audioList: List<SVGAAudioEntity> = emptyList()
     internal var soundPool: SoundPool? = null
-    private var soundCallback: SVGASoundManager.CompleteCallBack? = null
+    private var soundCallback: SVGASoundManager.SVGASoundCallBack? = null
     internal var imageMap = HashMap<String, Bitmap>()
     private var mCacheDir: File
     private var mFrameHeight = 0
@@ -286,8 +286,12 @@ class SVGAVideoEntity {
 
     private fun setupSoundPool(entity: MovieEntity, completionBlock: () -> Unit) {
         var soundLoaded = 0
-        if (SVGASoundManager.get().isInit()) {
-            soundCallback = object : SVGASoundManager.CompleteCallBack {
+        if (SVGASoundManager.isInit()) {
+            soundCallback = object : SVGASoundManager.SVGASoundCallBack {
+                override fun onVolumeChange(value: Float) {
+                    SVGASoundManager.setVolume(value, this@SVGAVideoEntity)
+                }
+
                 override fun onComplete() {
                     soundLoaded++
                     if (soundLoaded >= entity.audios.count()) {

--- a/library/src/main/java/com/opensource/svgaplayer/drawer/SVGACanvasDrawer.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/drawer/SVGACanvasDrawer.kt
@@ -157,9 +157,9 @@ internal class SVGACanvasDrawer(videoItem: SVGAVideoEntity, val dynamicItem: SVG
     private fun playAudio(frameIndex: Int) {
         this.videoItem.audioList.forEach { audio ->
             if (audio.startFrame == frameIndex) {
-                if (SVGASoundManager.get().isInit()) {
+                if (SVGASoundManager.isInit()) {
                     audio.soundID?.let { soundID ->
-                        audio.playID = SVGASoundManager.get().play(soundID, 1.0f, 1.0f, 1, 0, 1.0f)
+                        audio.playID = SVGASoundManager.play(soundID)
                     }
                 } else {
                     this.videoItem.soundPool?.let { soundPool ->
@@ -172,8 +172,8 @@ internal class SVGACanvasDrawer(videoItem: SVGAVideoEntity, val dynamicItem: SVG
             }
             if (audio.endFrame <= frameIndex) {
                 audio.playID?.let {
-                    if (SVGASoundManager.get().isInit()){
-                        SVGASoundManager.get().stop(it)
+                    if (SVGASoundManager.isInit()){
+                        SVGASoundManager.stop(it)
                     }else{
                         this.videoItem.soundPool?.stop(it)
                     }

--- a/library/src/main/java/com/opensource/svgaplayer/utils/log/DefaultLogCat.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/utils/log/DefaultLogCat.kt
@@ -22,15 +22,7 @@ class DefaultLogCat : ILogger {
         Log.w(tag, msg)
     }
 
-    override fun error(tag: String, msg: String) {
-        Log.e(tag, msg)
-    }
-
-    override fun error(tag: String, error: Throwable) {
-        Log.e(tag, "", error)
-    }
-
-    override fun error(tag: String, msg: String, error: Throwable) {
+    override fun error(tag: String, msg: String?, error: Throwable?) {
         Log.e(tag, msg, error)
     }
 }

--- a/library/src/main/java/com/opensource/svgaplayer/utils/log/ILogger.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/utils/log/ILogger.kt
@@ -8,7 +8,5 @@ interface ILogger {
     fun info(tag: String, msg: String)
     fun debug(tag: String, msg: String)
     fun warn(tag: String, msg: String)
-    fun error(tag: String, msg: String)
-    fun error(tag: String, error: Throwable)
-    fun error(tag: String, msg: String, error: Throwable)
+    fun error(tag: String, msg: String?, error: Throwable?)
 }

--- a/library/src/main/java/com/opensource/svgaplayer/utils/log/LogUtils.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/utils/log/LogUtils.kt
@@ -38,7 +38,14 @@ internal object LogUtils {
         if (!SVGALogger.isLogEnabled()) {
             return
         }
-        SVGALogger.getSVGALogger()?.error(tag, msg)
+        SVGALogger.getSVGALogger()?.error(tag, msg, null)
+    }
+
+    fun error(tag: String, error: Throwable) {
+        if (!SVGALogger.isLogEnabled()) {
+            return
+        }
+        SVGALogger.getSVGALogger()?.error(tag, error.message, error)
     }
 
     fun error(tag: String = TAG, msg: String, error: Throwable) {
@@ -46,12 +53,5 @@ internal object LogUtils {
             return
         }
         SVGALogger.getSVGALogger()?.error(tag, msg, error)
-    }
-
-    fun error(tag: String, error: Throwable) {
-        if (!SVGALogger.isLogEnabled()) {
-            return
-        }
-        SVGALogger.getSVGALogger()?.error(tag, error)
     }
 }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -10,6 +10,7 @@
         <attr name="fillMode" format="enum">
             <enum name="Backward" value="0" />
             <enum name="Forward" value="1" />
+            <enum name="Clear" value="2"/>
         </attr>
     </declare-styleable>
 </resources>

--- a/readme.md
+++ b/readme.md
@@ -99,25 +99,24 @@ Defaults to `0`.
 
 How many times should animation loops. `0` means Infinity Loop.
 
-#### clearsAfterStop: Boolean
+#### ~~clearsAfterStop: Boolean~~
 
-Defaults to `true`.
-
-Clears canvas after animation stop.
+Defaults to `true`.When the animation is finished, whether to clear the canvas and the internal data of SVGAVideoEntity.
+It is no longer recommended. Developers can control resource release through clearAfterDetached, or manually control resource release through SVGAVideoEntity#clear
 
 #### clearsAfterDetached: Boolean
 
-Defaults to `true`.
-
-Clears canvas after SVGAImageView detached.
+Defaults to `false`.Clears canvas and the internal data of SVGAVideoEntity after SVGAImageView detached.
 
 #### fillMode: String
 
-Defaults to `Forward`. Could be `Forward`, `Backward`.
+Defaults to `Forward`. Could be `Forward`, `Backward`, `Clear`.
 
 `Forward` means animation will pause on last frame after finished.
 
 `Backward` means animation will pause on first frame after finished.
+
+'Clear' after the animation is played, all the canvas content is cleared, but it is only the canvas and does not involve the internal data of SVGAVideoEntity.
 
 ### Using code
 

--- a/readme.md
+++ b/readme.md
@@ -151,18 +151,24 @@ You can also create `SVGAParser` instance by yourself.
 
 ```kotlin
 parser = new SVGAParser(this);
-parser.decodeFromAssets("posche.svga", new SVGAParser.ParseCompletion() {
+// The third parameter is a default parameter, which is null by default. If this method is set, the audio parsing and playback will not be processed internally. The audio File instance will be sent back to the developer through PlayCallback, and the developer will control the audio playback and playback. stop
+parser.decodeFromAssets("posche.svga", object : SVGAParser.ParseCompletion {
     // ...
-});
+}, object : SVGAParser.PlayCallback {
+    // The default is null, can not be set
+})
 ```
 
 #### Create a `SVGAParser` instance, parse from remote server like this.
 
 ```kotlin
 parser = new SVGAParser(this);
+// The third parameter is a default parameter, which is null by default. If this method is set, the audio parsing and playback will not be processed internally. The audio File instance will be sent back to the developer through PlayCallback, and the developer will control the audio playback and playback. stop
 parser.decodeFromURL(new URL("https://github.com/yyued/SVGA-Samples/blob/master/posche.svga?raw=true"), new SVGAParser.ParseCompletion() {
-    
-});
+    // ...
+}, object : SVGAParser.PlayCallback {
+    // The default is null, can not be set
+})
 ```
 
 #### Create a `SVGADrawable` instance then set to `SVGAImageView`, play it as you want.
@@ -202,6 +208,11 @@ HttpResponseCache.install(cacheDir, 1024 * 1024 * 128)
 Updated the internal log output, which can be managed and controlled through SVGALogger. It is not activated by default. Developers can also implement the ILogger interface to capture and collect logs externally to facilitate troubleshooting
 Set whether the log is enabled through the `setLogEnabled` method
 Inject a custom ILogger implementation class through the `injectSVGALoggerImp` method
+
+### SVGASoundManager
+Added SVGASoundManager to control SVGA audio, you need to manually call the init method to initialize, otherwise follow the default audio loading logic.
+In addition, through SVGASoundManager#setVolume, you can control the volume of SVGA playback. The range is [0f, 1f]. By default, the volume of all SVGA playbacks is controlled.
+And this method can set a second default parameter: SVGAVideoEntity, which means that only the current SVGA volume is controlled, and the volume of other SVGAs remains unchanged.
 
 ## Features
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -132,18 +132,24 @@ SVGAParser.shareParser().init(this);
 
 ```kotlin
 parser = new SVGAParser(this);
-parser.decodeFromAssets("posche.svga", new SVGAParser.ParseCompletion() {
-    
-});
+// 第三个为可缺省参数，默认为 null，如果设置该方法，则内部不在处理音频的解析以及播放，会通过 PlayCallback 把音频 File 实例回传给开发者，有开发者自行控制音频的播放与停止。
+parser.decodeFromAssets("posche.svga", object : SVGAParser.ParseCompletion {
+    // ...
+}, object : SVGAParser.PlayCallback {
+    // The default is null, can not be set
+})
 ```
 
 #### 创建一个 `SVGAParser` 实例，加载远端服务器中的动画。
 
 ```kotlin
 parser = new SVGAParser(this);
+// 第三个为可缺省参数，默认为 null，如果设置该方法，则内部不在处理音频的解析以及播放，会通过 PlayCallback 把音频 File 实例回传给开发者，有开发者自行控制音频的播放与停止。
 parser.decodeFromURL(new URL("https://github.com/yyued/SVGA-Samples/blob/master/posche.svga?raw=true"), new SVGAParser.ParseCompletion() {
-    
-});
+    // ...
+}, object : SVGAParser.PlayCallback {
+    // The default is null, can not be set
+})
 ```
 
 #### 创建一个 `SVGADrawable` 实例，并赋值给 `SVGAImageView`，然后播放动画。
@@ -183,6 +189,11 @@ HttpResponseCache.install(cacheDir, 1024 * 1024 * 128)
 更新了内部 log 输出，可通过 SVGALogger 去管理和控制，默认是未启用 log 输出，开发者们也可以实现 ILogger 接口，做到外部捕获收集 log，方便排查问题
 通过 `setLogEnabled` 方法设置日志是否开启
 通过 `injectSVGALoggerImp` 方法注入自定义 ILogger 实现类
+
+### SVGASoundManager
+新增 SVGASoundManager 控制 SVGA 音频，需要手动调用 init 方法进行初始化，否则按照默认的音频加载逻辑。
+另外通过 SVGASoundManager#setVolume 可控制 SVGA 播放时的音量大小，范围值在 [0f, 1f]，默认控制所有 SVGA 播放时的音量，
+而且该方法可设置第二个可缺省参数：SVGAVideoEntity，表示仅控制当前 SVGA 的音量大小，其他 SVGA 的音量保持不变。
 
 ## 功能示例
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -86,19 +86,22 @@ SVGAPlayer 可以从本地 `assets` 目录，或者远端服务器上加载动�
 #### loopCount: Int
 默认为 `0`，设置动画的循环次数，0 表示无限循环。
 
-#### clearsAfterStop: Boolean
-默认为 `true`，当动画播放完成后，是否清空画布。
+#### ~~clearsAfterStop: Boolean~~
+默认为 `true`，当动画播放完成后，是否清空画布，以及 SVGAVideoEntity 内部数据。
+不再推荐使用，开发者可以通过 clearAfterDetached 控制资源释放，或者手动通过 SVGAVideoEntity#clear 控制资源释放
 
 #### clearsAfterDetached: Boolean
-默认为 `true`，当 SVGAImageView 触发 onDetachedFromWindow 方法时，是否清空画布。
+默认为 `false`，当 SVGAImageView 触发 onDetachedFromWindow 方法时，是否清空画布。
 
 #### fillMode: String
 
-默认为 `Forward`，可以是 `Forward`、 `Backward`。
+默认为 `Forward`，可以是 `Forward`、 `Backward`、 `Clear`。
 
 `Forward` 表示动画结束后，将停留在最后一帧。
 
 `Backward` 表示动画结束后，将停留在第一帧。
+
+`Clear` 表示动画播放完后，清空所有画布内容，但仅仅是画布，不涉及 SVGAVideoEntity 内部数据。
 
 ### 使用代码
 


### PR DESCRIPTION
- SVGASoundManager 单例模式优化
- SVGASoundManager 加入音量控制，可通过 SVGASoundManager#setVolume 控制 #374 ，范围值在 [0f, 1f] 间，设置为 0f，则内部不会发声 #247 
- 根据 #371 的建议，对 clearAfterStop 添加 Deprecated 标记，clearsAfterDetached 默认设置为 false，但资源释放可通过 SVGAVideoEntity#clear 控制，同时修复 onDetachedFromWindow 内部 stopAnimation 用为 true 问题，该标记由 clearsAfterDetached 控制 #368 
- zip 路径穿透优化 #373 