### PR TITLE
fix: 更新 kotlin-stdlib 和 wire-runtime 版本, 避免安全漏洞风险

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 28
@@ -17,8 +16,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    productFlavors {
-    }
     packagingOptions {
         exclude 'META-INF/ASL2.0'
         exclude 'META-INF/LICENSE'
@@ -27,12 +24,15 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/MANIFEST.MF'
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation project(':library')
-    implementation 'com.squareup.okhttp3:okhttp:3.4.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,17 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
-    ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20"
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 
 android {
@@ -8,8 +7,6 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 28
-        versionCode 1
-        versionName "1.0"
     }
     compileOptions {
         kotlinOptions.freeCompilerArgs += ['-module-name', "com.opensource.svgaplayer"]
@@ -20,7 +17,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    productFlavors {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     packagingOptions {
         exclude 'META-INF/ASL2.0'
@@ -34,10 +33,5 @@ android {
 
 
 dependencies {
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.squareup.wire:wire-runtime:2.3.0-RC1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}
-repositories {
-    mavenCentral()
+    implementation 'com.squareup.wire:wire-runtime:4.4.1'
 }


### PR DESCRIPTION
通过与 nvd 漏洞库匹配, 发现以下依赖存在安全漏洞风险, 希望通过更新至较新的依赖库解决以下问题并发布新的版本.

kotlin-1.3.50:
[CVE-2020-29582](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-29582)
[CVE-2022-24329](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-24329)

wire-runtime-2.3.0-RC1:
[CVE-2020-27853](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-27853)
[CVE-2021-41093](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-41093)
[CVE-2020-15258](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-15258)
[CVE-2021-32665](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-32665)
[CVE-2021-32666](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-32666)
[CVE-2022-23625](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-23625)
[CVE-2022-31009](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-31009)
[CVE-2021-21301](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-21301)
[CVE-2021-32755](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-32755)