### PR TITLE
bug: 修改svga图片缩放模式

### DIFF
--- a/library/src/main/java/com/opensource/svgaplayer/bitmap/BitmapSampleSizeCalculator.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/bitmap/BitmapSampleSizeCalculator.kt
@@ -8,9 +8,19 @@ import android.graphics.BitmapFactory
  */
 internal object BitmapSampleSizeCalculator {
 
+    /**
+     * 根据BitmapFactory.Options 与期望宽高计算采样率
+     * */
     fun calculate(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
         // Raw height and width of image
         val (height: Int, width: Int) = options.run { outHeight to outWidth }
+        return calculate(height, width, reqWidth, reqHeight)
+    }
+
+    /**
+     * 根据预期显示的宽高 与实际宽高计算采样率
+     * */
+    fun calculate(height: Int, width: Int, reqWidth: Int, reqHeight: Int): Int {
         var inSampleSize = 1
 
         if (reqHeight <= 0 || reqWidth <= 0) {

--- a/library/src/main/java/com/opensource/svgaplayer/bitmap/SVGABitmapDecoder.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/bitmap/SVGABitmapDecoder.kt
@@ -31,5 +31,14 @@ internal abstract class SVGABitmapDecoder<T> {
         }
     }
 
+    fun decodeBitmapFrom(data: T, sampleSize:Int): Bitmap? = BitmapFactory.Options().run {
+        // 如果期望的宽高是合法的, 则开启检测尺寸模式
+        inPreferredConfig = Bitmap.Config.RGB_565
+        inJustDecodeBounds = false
+        // Calculate inSampleSize
+        inSampleSize = sampleSize
+        return onDecode(data, this)
+    }
+
     abstract fun onDecode(data: T, ops: BitmapFactory.Options): Bitmap?
 }


### PR DESCRIPTION
原因：svga 是由多张图片构成，图片有大有小。外界传递进来的宽高当前View 使用的期望宽高，将svga 中的所有图片根据同一个宽高去进行采样率计算明显不合理。比如 一张svga 包含三张图片假设三张图都是正方向  他们的宽度分别是800、400、200 期望大小是200  那么计算出的采样率分别是 4、2、1 那么在进行图片获取的时候会将三张图片最终加载成同样大小。
解决方式：读取svga 最外层的实际大小，以此作为基础与期望的图片大小进行采样率计算。然后svga内部的所有图片按照这个采样率进行采样